### PR TITLE
feat(react): add watch API to SmartStepper context

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ orchestration: {
 - Provides a `useSmartStepper` hook for step components to access navigation methods and form control:
   - `navigateToNextStep`: Moves to the next step in the sequence. Optionally accepts a target step name and unregister flag.
   - `navigateToPreviousStep`: Moves to the previous step in the history.
-  - `registerStepperFields`, `getStepperFieldValues`, `setStepperFieldValues`, `stepperFieldResetter`, `canNavigateToNextStep`, `control` for React Hook Form integration.
+  - `registerStepperFields`, `getStepperFieldValues`, `setStepperFieldValues`, `stepperFieldResetter`, `canNavigateToNextStep`, `control`, `watchStepperFieldValues` for React Hook Form integration.
 
 ### Validation Integration with React Hook Form
 - Seamlessly integrates with `react-hook-form` for field-level validation within each step.
@@ -197,6 +197,7 @@ The `SmartStepper` component utilizes React Context to provide methods and form 
 | `stepperFieldResetter`           | **React Hook Form integration:** A wrapper around `useForm().reset` for resetting the entire form state.          |
 | `canNavigateToNextStep`          | **React Hook Form integration:** Triggers validation for the current step's fields, returns a Promise of validity.|
 | `control`                        | **React Hook Form integration:** The `control` object provided by `useForm`, for use with `Controller` or `useController`.        |
+| `watchStepperFieldValues`        | **React Hook Form integration:** A wrapper around `useForm().watch` for observing all or specific field values in real time.      |
 | `useSmartStepper`                | Custom hook to access the SmartStepper context in your step components.                                           |
 | `useSmartStepperController`      | Custom hook to create a react-hook-form controller bound to the SmartStepper's form control.                      |
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -57,7 +57,7 @@ orchestration: {
 - Provides a `useSmartStepper` hook for step components to access navigation methods and form control:
   - `navigateToNextStep`: Moves to the next step in the sequence. Optionally accepts a target step name and unregister flag.
   - `navigateToPreviousStep`: Moves to the previous step in the history.
-  - `registerStepperFields`, `getStepperFieldValues`, `setStepperFieldValues`, `stepperFieldResetter`, `canNavigateToNextStep`, `control` for React Hook Form integration.
+  - `registerStepperFields`, `getStepperFieldValues`, `setStepperFieldValues`, `stepperFieldResetter`, `canNavigateToNextStep`, `control`, `watchStepperFieldValues` for React Hook Form integration.
 
 ### Validation Integration with React Hook Form
 - Seamlessly integrates with `react-hook-form` for field-level validation within each step.
@@ -197,6 +197,7 @@ The `SmartStepper` component utilizes React Context to provide methods and form 
 | `stepperFieldResetter`           | **React Hook Form integration:** A wrapper around `useForm().reset` for resetting the entire form state.          |
 | `canNavigateToNextStep`          | **React Hook Form integration:** Triggers validation for the current step's fields, returns a Promise of validity.|
 | `control`                        | **React Hook Form integration:** The `control` object provided by `useForm`, for use with `Controller` or `useController`.        |
+| `watchStepperFieldValues`        | **React Hook Form integration:** A wrapper around `useForm().watch` for observing all or specific field values in real time.      |
 | `useSmartStepper`                | Custom hook to access the SmartStepper context in your step components.                                           |
 | `useSmartStepperController`      | Custom hook to create a react-hook-form controller bound to the SmartStepper's form control.                      |
 

--- a/packages/react/src/_component.tsx
+++ b/packages/react/src/_component.tsx
@@ -1,9 +1,7 @@
 import {
-  cloneElement,
-  isValidElement,
   useMemo,
   useState,
-  type FormEvent,
+  type FormEvent
 } from 'react';
 import {
   useForm,
@@ -14,6 +12,7 @@ import {
   type UseFormRegister,
   type UseFormReset,
   type UseFormSetValue,
+  type UseFormWatch,
 } from 'react-hook-form';
 import SmartStepperContext from './_context';
 import { SmartStepperProps } from './_types';
@@ -22,7 +21,7 @@ const SmartStepper = <S extends string>({ config }: SmartStepperProps<S>) => {
   const [step, setStep] = useState<S>(config.start);
   const [historyStack, setHistoryStack] = useState<S[]>([]);
 
-  const { control, trigger, getValues, setValue, register, unregister, reset } =
+  const { control, trigger, getValues, setValue, register, unregister, reset, watch } =
     useForm({
       resolver: async (data) => {
         const current = config.validations[step];
@@ -152,11 +151,6 @@ const SmartStepper = <S extends string>({ config }: SmartStepperProps<S>) => {
   };
 
   const content = config.views[step]?.component;
-  const wrapper = config.views[step]?.wrapper;
-  const wrappedContent =
-    wrapper && isValidElement(wrapper)
-      ? cloneElement(wrapper, {}, content)
-      : content;
   return (
     <SmartStepperContext.Provider
       value={{
@@ -168,9 +162,10 @@ const SmartStepper = <S extends string>({ config }: SmartStepperProps<S>) => {
         stepperFieldResetter: reset as UseFormReset<FieldValues>,
         canNavigateToNextStep: async () => trigger(currentStepSchemaFields),
         control: control as Control<FieldValues>,
+        watchStepperFieldValues: watch as UseFormWatch<FieldValues>,
       }}
     >
-      <form onSubmit={handleSubmit}>{wrappedContent}</form>
+      <form onSubmit={handleSubmit}>{content}</form>
     </SmartStepperContext.Provider>
   );
 };

--- a/packages/react/src/_types.ts
+++ b/packages/react/src/_types.ts
@@ -1,9 +1,14 @@
 import type { HTMLAttributes, ReactElement } from 'react';
 import type {
-    Control, FieldValues, Resolver, UseControllerProps, UseFormGetValues,
-    UseFormRegister,
-    UseFormReset,
-    UseFormSetValue
+  Control,
+  FieldValues,
+  Resolver,
+  UseControllerProps,
+  UseFormGetValues,
+  UseFormRegister,
+  UseFormReset,
+  UseFormSetValue,
+  UseFormWatch,
 } from 'react-hook-form';
 import type { AnyObjectSchema } from 'yup';
 import type { ZodSchema } from 'zod';
@@ -64,10 +69,6 @@ export interface SmartStepperConfig<S extends string> {
        * The React component to render for this step.
        */
       component: ReactElement;
-      /**
-       * Optional wrapper React element for the step.
-       */
-      wrapper?: ReactElement;
     };
   };
   /**
@@ -130,6 +131,10 @@ export interface ISmartStepperContextValue<T extends FieldValues> {
    * React Hook Form control object for the stepper.
    */
   control: Control<T, T>;
+  /**
+   * Watch values for the stepper fields.
+   */
+  watchStepperFieldValues: UseFormWatch<T>;
 }
 
 /**


### PR DESCRIPTION
- Add UseFormWatch to ISmartStepperContextValue as `watchStepperFieldValues`
- Expose `watch` from useForm via SmartStepperContext.Provider
- Update README docs to include `watchStepperFieldValues` in context features and table

No breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added watchStepperFieldValues to the SmartStepper context for real-time observation of all or specific field values with React Hook Form.

* **Refactor**
  * Simplified step content rendering by removing per-step wrapper support; content now renders directly within the form.

* **Documentation**
  * Updated README to include watchStepperFieldValues in the React Hook Form integration section, with usage details and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->